### PR TITLE
Fix typo in feedback section. #28

### DIFF
--- a/templates/root.html
+++ b/templates/root.html
@@ -8,8 +8,8 @@
     <link href="css/bootstrap.min.css" rel="stylesheet" media="screen">
     <link href="https://fonts.googleapis.com/css?family=Philosopher:400,700,400italic,700italic" rel="stylesheet" type="text/css">
     <link href="css/cheatsheet.css" rel="stylesheet" media="screen">
-    <link rel="icon" 
-	  type="image/png" 
+    <link rel="icon"
+	  type="image/png"
 	  href="http://www.xogeny.com/favicon.ico">
   </head>
   <body>
@@ -153,7 +153,7 @@
 		      </p>
 		      <p>
 			Even better, fork the repository and submit a pull
-			request with your suggested changed.
+			request with your suggested changes.
 		      </p>
 		      <p>We appreciate any and all feedback.</p>
 		    </div>


### PR DESCRIPTION
Changes "with your suggested change**d**" to "with your suggested change**s**".

Also, the text editor removed two trailing white spaces. If you prefer not to have the white space changes, I can of course undo them.
